### PR TITLE
updates for more efficient binary fetch + updated BB syntax

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -7,16 +7,13 @@ version = v"2.2.0"
 
 # Collection of sources required to download ROCm-Device-Libs
 sources = [
-    "http://repo.radeon.com/rocm/archive/apt_2.2.0.tar.bz2" =>
-    "a0013c4b4282f6295cb3f34566b0f13e0db030bb39c4364430f4108d16782f97",
-
+    FileSource("http://repo.radeon.com/rocm/apt/2.2/pool/main/r/rocm-device-libs/rocm-device-libs_0.0.1_amd64.deb",
+               "95a8440119f3269b21c68ecd2483b9e77fb56029ccefdbec910259a5583c54d6"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
-mv ./apt* apt/
-mv apt/pool/main/r/rocm-device-libs/rocm-device-libs_0.0.1_amd64.deb .
 ar x rocm-device-libs_0.0.1_amd64.deb
 tar xf data.tar.gz
 mv opt/rocm/lib/ ../destdir/
@@ -26,14 +23,14 @@ mv opt/rocm/lib/ ../destdir/
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64, :glibc),
-    Linux(:x86_64, :musl)
+    Linux(:x86_64, libc=:glibc),
+    Linux(:x86_64, libc=:musl)
 ]
 
 # The products that we will ensure are always built
-products(prefix) = [
+products = [
     # TODO: A better way to emulate a FolderProduct would be nice
-    FileProduct(prefix, "lib/ockl.amdgcn.bc", :rocmdevlibdir),
+    FileProduct("lib/ockl.amdgcn.bc", :rocmdevlibdir),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
see title. This pulls the device lib deb package directly instead of downloading the ~1GB total release file. Result is the same with less syntax + bandwidth usage. Syntax has also been updated to be compatible with latest version of `BinaryBuilder.jl`