### PR TITLE
updates for ROCm v2.7.2 device libs

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -3,20 +3,17 @@
 using BinaryBuilder
 
 name = "ROCmDeviceLibsDownloader"
-version = v"2.2.0"
+version = v"2.7.2"
 
 # Collection of sources required to download ROCm-Device-Libs
 sources = [
-    "http://repo.radeon.com/rocm/archive/apt_2.2.0.tar.bz2" =>
-    "a0013c4b4282f6295cb3f34566b0f13e0db030bb39c4364430f4108d16782f97",
-
+    FileSource("http://repo.radeon.com/rocm/apt/2.7.2/pool/main/r/rocm-device-libs/rocm-device-libs_0.0.1_amd64.deb",
+               "9db86575acf665a641b20c23ca8104ea749bb75f1128c18718cec5ac4912a792"),
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
 cd $WORKSPACE/srcdir
-mv ./apt* apt/
-mv apt/pool/main/r/rocm-device-libs/rocm-device-libs_0.0.1_amd64.deb .
 ar x rocm-device-libs_0.0.1_amd64.deb
 tar xf data.tar.gz
 mv opt/rocm/lib/ ../destdir/
@@ -26,14 +23,14 @@ mv opt/rocm/lib/ ../destdir/
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = [
-    Linux(:x86_64, :glibc),
-    Linux(:x86_64, :musl)
+    Linux(:x86_64, libc=:glibc),
+    Linux(:x86_64, libc=:musl)
 ]
 
 # The products that we will ensure are always built
-products(prefix) = [
+products = [
     # TODO: A better way to emulate a FolderProduct would be nice
-    FileProduct(prefix, "lib/ockl.amdgcn.bc", :rocmdevlibdir),
+    FileProduct("lib/ockl.amdgcn.bc", :rocmdevlibdir),
 ]
 
 # Dependencies that must be installed before this package can be built


### PR DESCRIPTION
This should work for Julia v1.4+ (LLVM 8+) as it was the last major release from ROCm where the bitcode was built with LLVM 8